### PR TITLE
.LMP support now included!

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Palpatine 256
 
 Palpatine 256 supports the conversion of PNG, Microsoft Palette, Build Engine PALETTE.DAT,
-JASC Palette, GIMP GPL, and Photoshop ACT palettes to 8-bit PNG, 
+JASC Palette, GIMP GPL, Raw .LMP and Photoshop ACT palettes to 8-bit PNG, 
 Microsoft Palette, JASC Palette, GIMP GPL, or Photoshop ACT,
 while preserving the original index order of the source file.
 

--- a/src/ppt256.py
+++ b/src/ppt256.py
@@ -380,7 +380,7 @@ file, select File > Export File and choose GIMP .gpl.
 root = tk.Tk()
 root.title("Palpatine 256")
 root.geometry("570x620")
-# root.iconbitmap(resource_path("icon.ico"))
+root.iconbitmap(resource_path("icon.ico"))
 
 frame = tk.Frame(root)
 frame.pack(expand=True)


### PR DESCRIPTION
All other file I/O's unchanged.

Support for 256 color palette in id's binary .LMP format will now import and export.

(Tested with Quake1 palette.lmp and playpal-base.lmp)